### PR TITLE
updated training links with deploying cloud foundry with bosh tutorial

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -61,6 +61,7 @@
             <li><a href="https://groups.google.com/a/cloudfoundry.org/forum/#!topic/bosh-users/SJDXbNvQtr8">Compare with Chef and Puppet Matrix</a></li>
             <li><a href="http://www.youtube.com/watch?v=6G3zYusffuw">BOSH Hadoop on GCE</a></li>
             <li><a href="http://www.oscon.com/oscon2013/public/schedule/detail/29346">BOSH at OSCON 2013</a></li>
+            <li><a href="http://docs.cloudfoundry.com/docs/running/deploying-cf/">Deploying Cloud Foundry with BOSH Tutorial</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
I found the tutorial very helpful in getting started with understanding Bosh and think it should be included as a learning link.
